### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,9 @@ u2:
 
 flash-u2:
 	BLBAUD=115200 SERIAL_DEV=/dev/ttyACM0 $(MAKE) program
+	
+flash-ch341:
+	BLBAUD=115200 SERIAL_DEV=/dev/ttyUSB0 $(MAKE) program
 
 ftdi:
 	$(MAKE) clean


### PR DESCRIPTION
Added support for a Arduino Uno r3 clone which uses a ch341-uart chip. 

Commands: make u2 and sudo make flash-ch341. 